### PR TITLE
Set Vane To Previous Setting When Switching Climate Modes

### DIFF
--- a/esphome/components/lg_controller/lg-controller.h
+++ b/esphome/components/lg_controller/lg-controller.h
@@ -1473,10 +1473,19 @@ private:
             }
             return;
         }
-        // Send a status message every 20 seconds, or now if we have a pending change.
+        // send a status message if there is a pending change
+        // additionally, queue a type a message after sending the status message 
+        // if the swing mode does not include vertical, then the vane will be set to the previous setting
+        if (pending_status_change_) {
+            if (check_can_send()) {
+                send_status_message();
+                pending_type_a_settings_change_ = true;
+            }
+            return;
+        }
+        // Send a status message every 20 seconds
         // Slave controllers only send this if needed.
-        if (pending_status_change_ ||
-            (!slave_ && millis_now - last_sent_status_millis_ > 20 * 1000)) {
+        if ((!slave_ && millis_now - last_sent_status_millis_ > 20 * 1000)) {
             if (check_can_send()) {
                 send_status_message();
             }


### PR DESCRIPTION
Hey there, 

This PR is to solve an issue I've been having with my minisplits. If you had previously set your swing mode to none or horizontal _and then_ switch climate modes or go from off to on, the vane will always be set to "default" irrespective of what was set in HomeAssistant. 

With this PR, whenever you toggle the climate settings or switch from off to on, the type a message will be queued so the saved vane setting will apply. 

I figured there's no need to send every 20 seconds like the status message, but only when the user had touched something related to the status of the minisplit itself. 