### PR TITLE
ESP-IDF compatibility

### DIFF
--- a/esphome/base.yaml
+++ b/esphome/base.yaml
@@ -6,6 +6,14 @@ esp32:
   board: esp32dev
   framework:
     type: arduino
+    #type: esp-idf
+
+#esp32_ble_tracker:
+#  scan_parameters:
+#    active: false
+
+#bluetooth_proxy:
+#  active: false
 
 uart:
   - id: ac_serial


### PR DESCRIPTION
Slight changes to the code to make it compatible with ESP-IDF.
The main advantage is to be able to use bluetooth proxy with BLE temperature sensors.
I've been using framework esp-idf to compile the code for 7 LG AC units for a couple of months with no issues.