### PR TITLE
Make temp sensor optional

### DIFF
--- a/esphome/components/lg_controller/climate.py
+++ b/esphome/components/lg_controller/climate.py
@@ -57,7 +57,7 @@ CONFIG_SCHEMA = climate.climate_schema(LgController).extend(
         cv.Required(CONF_FAHRENHEIT): cv.boolean,
         cv.Required(CONF_IS_SLAVE_CONTROLLER): cv.boolean,
 
-        cv.Required(CONF_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
+        cv.Optional(CONF_TEMPERATURE_SENSOR): cv.use_id(sensor.Sensor),
 
         cv.Required(CONF_VANE1): select.select_schema(LgSelect),
         cv.Required(CONF_VANE2): select.select_schema(LgSelect),
@@ -90,7 +90,10 @@ CONFIG_SCHEMA = climate.climate_schema(LgController).extend(
 async def to_code(config):
     rx_pin = await cg.gpio_pin_expression(config[CONF_RX_PIN])
 
-    temperature_sensor = await cg.get_variable(config[CONF_TEMPERATURE_SENSOR])
+    if CONF_TEMPERATURE_SENSOR in config:
+        temperature_sensor = await cg.get_variable(config[CONF_TEMPERATURE_SENSOR])
+    else:
+        temperature_sensor = cg.nullptr
 
     vane1 = await select.new_select(config[CONF_VANE1], options=VANE_OPTIONS)
     vane2 = await select.new_select(config[CONF_VANE2], options=VANE_OPTIONS)

--- a/esphome/components/lg_controller/lg-controller.h
+++ b/esphome/components/lg_controller/lg-controller.h
@@ -134,7 +134,7 @@ class LgController final : public climate::Climate, public uart::UARTDevice, pub
     climate::ClimateTraits supported_traits_{};
 
     InternalGPIOPin& rx_pin_;
-    esphome::sensor::Sensor& temperature_sensor_;
+    esphome::sensor::Sensor* temperature_sensor_;
 
     LgSelect& vane_select_1_;
     LgSelect& vane_select_2_;
@@ -430,7 +430,7 @@ public:
                  LgSwitch* auto_dry,
                  bool fahrenheit, bool is_slave_controller)
       : rx_pin_(*rx_pin),
-        temperature_sensor_(*temperature_sensor),
+        temperature_sensor_(temperature_sensor),
         vane_select_1_(*vane_select_1),
         vane_select_2_(*vane_select_2),
         vane_select_3_(*vane_select_3),
@@ -645,7 +645,11 @@ private:
     }
 
     optional<float> get_room_temp() const {
-        float temp = temperature_sensor_.get_state();
+        if (temperature_sensor_ == nullptr) {
+            return {};
+        }
+
+        float temp = temperature_sensor_->get_state();
         if (std::isnan(temp) || temp == 0) {
             return {};
         }


### PR DESCRIPTION
Hi!

I'm planning to use an ESP based controller purely as a replacement for the native WiFi module, without using any external temp sensors (at least for now). However I'm not a big fan of creating a sensor with [nonexistent ID](https://github.com/JanM321/esphome-lg-controller/issues/43#issuecomment-2773271766) just to satisfy the `required` parameter. I personally prefer cleaner approaches when possible :) 

I've looked at the code and found that this should be enough to make the temp sensor truly optional.

What do you think?

I tested it compiles and flashes fine in both cases, but I can test the physical connection to AC tomorrow.

EDIT: works fine on my end!