### PR TITLE
Fixing intermittent invalid checksum messages

### DIFF
--- a/esphome/components/lg_controller/lg-controller.h
+++ b/esphome/components/lg_controller/lg-controller.h
@@ -188,6 +188,7 @@ class LgController final : public climate::Climate, public uart::UARTDevice, pub
     bool pending_type_b_settings_change_ = false;
 
     bool is_initializing_ = true;
+    bool startup_flush_done_ = false;
 
     uint8_t vane_position_[4] = {0,0,0,0};
     uint8_t fan_speed_[4] = {0,0,0,0};
@@ -1276,6 +1277,22 @@ private:
     void update() {
         ESP_LOGD(TAG, "update");
 
+        // On the very first update() call, re-flush the UART buffer to discard
+        // bytes that accumulated during the 10-second setup→update gap.
+        // This is the primary cause of byte framing misalignment.
+        if (!startup_flush_done_) {
+            int flushed = 0;
+            while (UARTDevice::available() > 0) {
+                uint8_t discard;
+                if (!UARTDevice::read_byte(&discard)) break;
+                flushed++;
+            }
+            recv_buf_len_ = 0;
+            startup_flush_done_ = true;
+            ESP_LOGI(TAG, "Startup: flushed %d bytes from UART buffer before first read", flushed);
+            return;  // skip this update cycle, start clean next time
+        }
+
         bool had_error = false;
         while (UARTDevice::available() > 0) {
             if (!UARTDevice::read_byte(&recv_buf_[recv_buf_len_])) {
@@ -1284,8 +1301,18 @@ private:
             last_recv_millis_ = millis();
             recv_buf_len_++;
             if (recv_buf_len_ == MsgLen) {
-                process_message(recv_buf_, &had_error);
-                recv_buf_len_ = 0;
+                if (calc_checksum(recv_buf_) == recv_buf_[MsgLen - 1]) {
+                    // Valid frame — process normally
+                    process_message(recv_buf_, &had_error);
+                    recv_buf_len_ = 0;
+                } else {
+                    // Checksum mismatch — likely misaligned.
+                    // Drop the oldest byte, slide remaining 12 left.
+                    // The next UART byte will fill slot 13 for a new check.
+                    ESP_LOGW(TAG, "Checksum mismatch, sliding buffer by 1 byte");
+                    memmove(recv_buf_, recv_buf_ + 1, MsgLen - 1);
+                    recv_buf_len_ = MsgLen - 1;
+                }
             }
         }
 


### PR DESCRIPTION
# Problem
ESP32 starts reading UART mid-message after boot. Since the LG CN-REMO protocol has no start-of-frame marker, the 13-byte framing window gets permanently shifted. This causes checksum errors intermittently. I have 3 LG indoor units with wall controls running in a slave mode and 2 of them were nearly always going into inflnite loop of messages like these: 

[10:56:54.029][D][lg-controller:954]: received 00.00.00.00.00.00.00.00.00.00.F9.A8.20 (13)[10:56:54.029][E][lg-controller:964]: invalid checksum 00.00.00.00.00.00.00.00.00.00.F9.A8.20 (13)[10:56:54.033][D][lg-controller:954]: received 00.00.00.00.25.14.00.00.00.00.54.A8.20 (13)[10:56:54.036][E][lg-controller:964]: invalid checksum 00.00.00.00.25.14.00.00.00.00.54.A8.20 (13)[10:56:54.040][D][lg-controller:954]: received 00.00.00.00.25.14.00.00.00.00.54.AC.00 (13)[10:56:54.044][E][lg-controller:964]: invalid checksum 00.00.00.00.25.14.00.00.00.00.54.AC.00 (13)[10:56:54.047][D][lg-controller:954]: received 00.00.00.00.00.00.00.00.00.00.F9.AC.00 (13)[10:56:54.051][E][lg-controller:964]: invalid checksum 00.00.00.00.00.00.00.00.00.00.F9.AC.00 (13)[10:57:00.026][D][lg-controller:1360]: update

The fix below sorted it out and the messages are typically synced within a few cycles. 

## Fix: Two changes:

### 1: Startup re-flush (prevents the problem)

Added `startup_flush_done_` member variable and a guard at the top of `update()` that re-flushes the UART buffer on the first call. This clears bytes that accumulated during the 10-second setup-to-update gap (root cause).

### 2: Sliding window (recovers from misalignment)

On checksum failure, instead of discarding all 13 bytes, drops the oldest byte and slides remaining 12 bytes left. The next incoming byte completes a new 13-byte window for immediate re-evaluation. Converges within a single `update()` cycle since multiple bytes are typically buffered.

Uses the existing `calc_checksum()` function — no duplicated checksum logic.