### PR TITLE
Fix climate traits API compatibility

### DIFF
--- a/esphome/components/lg_controller/lg-controller.h
+++ b/esphome/components/lg_controller/lg-controller.h
@@ -285,30 +285,29 @@ class LgController final : public climate::Climate, public uart::UARTDevice, pub
 
     void configure_capabilities() {
         // Default traits
-        climate::ClimateModeMask device_modes;
-        device_modes.insert(climate::CLIMATE_MODE_OFF);
-        device_modes.insert(climate::CLIMATE_MODE_COOL);
-        device_modes.insert(climate::CLIMATE_MODE_HEAT);
-        device_modes.insert(climate::CLIMATE_MODE_DRY);
-        device_modes.insert(climate::CLIMATE_MODE_FAN_ONLY);
-        device_modes.insert(climate::CLIMATE_MODE_HEAT_COOL);
-        
-        climate::ClimateFanModeMask fan_modes;
-        fan_modes.insert(climate::CLIMATE_FAN_LOW);
-        fan_modes.insert(climate::CLIMATE_FAN_MEDIUM);
-        fan_modes.insert(climate::CLIMATE_FAN_HIGH);
-        fan_modes.insert(climate::CLIMATE_FAN_AUTO);
-        
-        climate::ClimateSwingModeMask swing_modes;
-        swing_modes.insert(climate::CLIMATE_SWING_OFF);
-        swing_modes.insert(climate::CLIMATE_SWING_BOTH);
-        swing_modes.insert(climate::CLIMATE_SWING_VERTICAL);
-        swing_modes.insert(climate::CLIMATE_SWING_HORIZONTAL);
-
-        supported_traits_.set_supported_modes(device_modes);
-        supported_traits_.set_supported_fan_modes(fan_modes);
-        supported_traits_.set_supported_swing_modes(swing_modes);
-        supported_traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+        supported_traits_.set_supported_modes({
+            climate::CLIMATE_MODE_OFF,
+            climate::CLIMATE_MODE_COOL,
+            climate::CLIMATE_MODE_HEAT,
+            climate::CLIMATE_MODE_DRY,
+            climate::CLIMATE_MODE_FAN_ONLY,
+            climate::CLIMATE_MODE_HEAT_COOL,
+        });
+        supported_traits_.set_supported_fan_modes({
+            climate::CLIMATE_FAN_LOW,
+            climate::CLIMATE_FAN_MEDIUM,
+            climate::CLIMATE_FAN_HIGH,
+            climate::CLIMATE_FAN_AUTO,
+        });
+        supported_traits_.set_supported_swing_modes({
+            climate::CLIMATE_SWING_OFF,
+            climate::CLIMATE_SWING_BOTH,
+            climate::CLIMATE_SWING_VERTICAL,
+            climate::CLIMATE_SWING_HORIZONTAL,
+        });
+        supported_traits_.set_supports_current_temperature(true);
+        supported_traits_.set_supports_two_point_target_temperature(false);
+        supported_traits_.set_supports_action(false);
         supported_traits_.set_visual_min_temperature(MIN_TEMP_SETPOINT);
         supported_traits_.set_visual_max_temperature(MAX_TEMP_SETPOINT);
         supported_traits_.set_visual_current_temperature_step(fahrenheit_ ? 1 : 0.5);
@@ -317,41 +316,35 @@ class LgController final : public climate::Climate, public uart::UARTDevice, pub
         // Only override defaults if the capabilities are known
         if (nvs_storage_.capabilities_message[0] != 0) {
             // Configure the climate traits
-            climate::ClimateModeMask override_device_modes;
-            override_device_modes.insert(climate::CLIMATE_MODE_OFF);
-            override_device_modes.insert(climate::CLIMATE_MODE_COOL);
+            supported_traits_.add_supported_mode(climate::CLIMATE_MODE_OFF);
+            supported_traits_.add_supported_mode(climate::CLIMATE_MODE_COOL);
             if (parse_capability(LgCapability::MODE_HEATING))
-                override_device_modes.insert(climate::CLIMATE_MODE_HEAT);
+                supported_traits_.add_supported_mode(climate::CLIMATE_MODE_HEAT);
             if (parse_capability(LgCapability::MODE_FAN))
-                override_device_modes.insert(climate::CLIMATE_MODE_FAN_ONLY);
+                supported_traits_.add_supported_mode(climate::CLIMATE_MODE_FAN_ONLY);
             if (parse_capability(LgCapability::MODE_AUTO))
-                override_device_modes.insert(climate::CLIMATE_MODE_HEAT_COOL);
+                supported_traits_.add_supported_mode(climate::CLIMATE_MODE_HEAT_COOL);
             if (parse_capability(LgCapability::MODE_DEHUMIDIFY))
-                override_device_modes.insert(climate::CLIMATE_MODE_DRY);
-            supported_traits_.set_supported_modes(override_device_modes);
+                supported_traits_.add_supported_mode(climate::CLIMATE_MODE_DRY);
 
-            climate::ClimateFanModeMask override_fan_modes;
             if (parse_capability(LgCapability::FAN_AUTO))
-                override_fan_modes.insert(climate::CLIMATE_FAN_AUTO);
+                supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_AUTO);
             if (parse_capability(LgCapability::FAN_SLOW))
-                override_fan_modes.insert(climate::CLIMATE_FAN_QUIET);
+                supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_QUIET);
             if (parse_capability(LgCapability::FAN_LOW))
-                override_fan_modes.insert(climate::CLIMATE_FAN_LOW);
+                supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_LOW);
             if (parse_capability(LgCapability::FAN_MEDIUM))
-                override_fan_modes.insert(climate::CLIMATE_FAN_MEDIUM);
+                supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_MEDIUM);
             if (parse_capability(LgCapability::FAN_HIGH))
-                override_fan_modes.insert(climate::CLIMATE_FAN_HIGH);
-            supported_traits_.set_supported_fan_modes(override_fan_modes);
+                supported_traits_.add_supported_fan_mode(climate::CLIMATE_FAN_HIGH);
 
-            climate::ClimateSwingModeMask override_swing_modes;
-            override_swing_modes.insert(climate::CLIMATE_SWING_OFF);
+            supported_traits_.add_supported_swing_mode(climate::CLIMATE_SWING_OFF);
             if (parse_capability(LgCapability::VERTICAL_SWING) && parse_capability(LgCapability::HORIZONTAL_SWING))
-                override_swing_modes.insert(climate::CLIMATE_SWING_BOTH);
+                supported_traits_.add_supported_swing_mode(climate::CLIMATE_SWING_BOTH);
             if (parse_capability(LgCapability::VERTICAL_SWING))
-                override_swing_modes.insert(climate::CLIMATE_SWING_VERTICAL);
+                supported_traits_.add_supported_swing_mode(climate::CLIMATE_SWING_VERTICAL);
             if (parse_capability(LgCapability::HORIZONTAL_SWING))
-                override_swing_modes.insert(climate::CLIMATE_SWING_HORIZONTAL);
-            supported_traits_.set_supported_swing_modes(override_swing_modes);
+                supported_traits_.add_supported_swing_mode(climate::CLIMATE_SWING_HORIZONTAL);
 
             // Disable unsupported entities
             vane_select_1_.set_internal(true);

--- a/esphome/components/lg_controller/lg-controller.h
+++ b/esphome/components/lg_controller/lg-controller.h
@@ -305,9 +305,9 @@ class LgController final : public climate::Climate, public uart::UARTDevice, pub
             climate::CLIMATE_SWING_VERTICAL,
             climate::CLIMATE_SWING_HORIZONTAL,
         });
-        supported_traits_.set_supports_current_temperature(true);
-        supported_traits_.set_supports_two_point_target_temperature(false);
-        supported_traits_.set_supports_action(false);
+        supported_traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+        // Two point target temperature not supported
+        // Action support not needed
         supported_traits_.set_visual_min_temperature(MIN_TEMP_SETPOINT);
         supported_traits_.set_visual_max_temperature(MAX_TEMP_SETPOINT);
         supported_traits_.set_visual_current_temperature_step(fahrenheit_ ? 1 : 0.5);


### PR DESCRIPTION
ESPHome changed the climate traits API from using mask types (ClimateModeMask, ClimateFanModeMask, ClimateSwingModeMask) with set_supported_modes() to individual add_supported_mode(), add_supported_fan_mode(), and add_supported_swing_mode() methods.

This fix updates configure_capabilities() to use the new API methods.
The specific ESPHome version where this change occurred is unclear as it is not documented in release notes, but compilation fails with the old API and succeeds with the new API.

Testing
- Successfully compiled with ESPHome 2026.4.2
- OTA upload successful
- Device running normally with updated firmware