### PR TITLE
[codex] Add LG Jet fan mode support

### DIFF
--- a/esphome/components/lg_controller/lg-controller.h
+++ b/esphome/components/lg_controller/lg-controller.h
@@ -9,6 +9,7 @@ namespace esphome::lg_controller {
 
 static constexpr size_t MIN_TEMP_SETPOINT = 16;
 static constexpr size_t MAX_TEMP_SETPOINT = 30;
+static constexpr const char *FAN_MODE_JET = "Jet";
 
 class LgSwitch final : public switch_::Switch {
     void write_state(bool value) override {
@@ -433,6 +434,8 @@ public:
         ESPPreferenceObject pref = global_preferences->make_preference<NVSStorage>(this->get_object_id_hash() ^ NVS_STORAGE_VERSION);
         pref.load(&nvs_storage_);
 
+        this->set_supported_custom_fan_modes({FAN_MODE_JET});
+
         auto restore = this->restore_state_();
         if (restore.has_value()) {
             restore->apply(this);
@@ -472,7 +475,10 @@ public:
             this->target_temperature = *call.get_target_temperature();
         }
         if (call.get_fan_mode().has_value()) {
-            this->fan_mode = *call.get_fan_mode();
+            this->set_fan_mode_(*call.get_fan_mode());
+        }
+        if (call.has_custom_fan_mode()) {
+            this->set_custom_fan_mode_(call.get_custom_fan_mode());
         }
         if (call.get_swing_mode().has_value()) {
             set_swing_mode(*call.get_swing_mode());
@@ -653,8 +659,9 @@ private:
                 break;
         }
         
-        // Fix: Check if fan_mode has a value before dereferencing
-        if (this->fan_mode.has_value()) {
+        if (this->has_custom_fan_mode()) {
+            b |= 7 << 5;
+        } else if (this->fan_mode.has_value()) {
             switch (this->fan_mode.value()) {
                 case climate::CLIMATE_FAN_LOW:
                     b |= 0 << 5;
@@ -1051,19 +1058,22 @@ private:
         uint8_t fan_val = b >> 5;
         switch (fan_val) {
             case 0:
-                this->fan_mode = climate::CLIMATE_FAN_LOW;
+                this->set_fan_mode_(climate::CLIMATE_FAN_LOW);
                 break;
             case 1:
-                this->fan_mode = climate::CLIMATE_FAN_MEDIUM;
+                this->set_fan_mode_(climate::CLIMATE_FAN_MEDIUM);
                 break;
             case 2:
-                this->fan_mode = climate::CLIMATE_FAN_HIGH;
+                this->set_fan_mode_(climate::CLIMATE_FAN_HIGH);
                 break;
             case 3:
-                this->fan_mode = climate::CLIMATE_FAN_AUTO;
+                this->set_fan_mode_(climate::CLIMATE_FAN_AUTO);
                 break;
             case 4:
-                this->fan_mode = climate::CLIMATE_FAN_QUIET;
+                this->set_fan_mode_(climate::CLIMATE_FAN_QUIET);
+                break;
+            case 7:
+                this->set_custom_fan_mode_(FAN_MODE_JET);
                 break;
             default:
                 ESP_LOGE(TAG, "received unexpected fan mode from AC (%u)", fan_val);


### PR DESCRIPTION
## Summary

Adds explicit support for LG Jet/Power fan mode in the ESPHome climate component.

The LG wired-controller protocol documents fan speed bits `7` as `power`. On the tested LG indoor unit this is the value emitted when Jet mode is enabled from the remote or app. The existing component treated that value as an unexpected fan mode, marked the incoming status message as an error, and then continued to send the previous normal fan mode back to the unit. In practice this made Jet mode drop back out after a few seconds.

## Root Cause

Incoming status byte `C8.E2...` / `C8.E3...` has the fan-speed bits set to `0b111` (`7`). Before this change, `process_status_message()` only accepted fan values `0..4` and returned early for value `7` with:

```text
received unexpected fan mode from AC (7)
```

Because the climate state never represented Jet, the next status send encoded the last normal fan mode, typically medium (`A8.22...`), which overwrote Jet mode on the AC bus.

## Changes

- Adds a custom ESPHome climate fan mode named `Jet`.
- Maps incoming LG protocol fan value `7` to the custom fan mode.
- Maps active custom fan mode `Jet` back to outgoing LG protocol fan value `7`.
- Uses ESPHome's `set_fan_mode_()` / `set_custom_fan_mode_()` helpers so standard fan modes and the custom fan mode remain mutually exclusive.

## Validation

Tested on a live LG Airco ESP32 controller with ESPHome 2026.5.1.

Configuration validation:

```text
INFO ESPHome 2026.5.1
INFO Reading configuration bioscoop-lg-airco.yaml...
INFO Configuration is valid!
```

Firmware build:

```text
INFO Successfully compiled program.
RAM:   [==        ]  21.3% (used 69952 bytes from 327680 bytes)
Flash: [=======   ]  70.6% (used 1295591 bytes from 1835008 bytes)
```

OTA flash:

```text
INFO OTA successful
INFO Successfully uploaded program.
```

Manual remote/app Jet capture before the fix showed the unsupported fan value:

```text
received C8.E2.00.00.00.04.13.50.00.00.00.00.44 (13)
received unexpected fan mode from AC (7)
sending A8.22.00.00.00.04.13.50.00.00.00.00.64 (13)
```

After the fix, setting `fan_mode: Jet` through Home Assistant produced the expected protocol bytes and remained active for more than one minute:

```text
18:36:03 sending A8.E3.00.00.00.04.13.51.00.00.40.00.66 (13)
18:36:09 received C8.E3.00.00.00.04.13.51.00.00.00.00.46 (13)
18:36:33 Custom Fan Mode: Jet
18:36:57 received C8.E3.00.00.00.04.13.51.00.00.00.00.46 (13)
18:37:21 received C8.E3.00.00.00.04.13.51.00.00.00.46.C8 (13)
```

Home Assistant also reported:

```text
fan_modes: [auto, low, medium, high, Jet]
fan_mode: Jet
```

No `unexpected fan mode` errors appeared after the change, and the controller no longer wrote medium fan mode over Jet.
