### PR TITLE
[codex] Add climate action and status telemetry

### DIFF
--- a/esphome/base.yaml
+++ b/esphome/base.yaml
@@ -105,6 +105,7 @@ climate:
       name: Error Code
       id: error_code
       icon: mdi:alert-circle-outline
+      accuracy_decimals: 0
     pipe_temp_in:
       name: Pipe Temperature In
       id: pipe_temperature_in
@@ -120,6 +121,18 @@ climate:
       id: pipe_temperature_out
       icon: mdi:thermometer
       unit_of_measurement: "°C"
+    humidity:
+      name: Humidity
+      id: humidity
+    fan_operation_time:
+      name: Fan Operation Time
+      id: fan_operation_time
+    indoor_unit_operation_time:
+      name: Indoor Unit Operation Time
+      id: indoor_unit_operation_time
+    precise_room_temperature:
+      name: Precise Room Temperature
+      id: precise_room_temperature
     defrost:
       name: Defrost
       id: defrost

--- a/esphome/components/lg_controller/climate.py
+++ b/esphome/components/lg_controller/climate.py
@@ -2,7 +2,19 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import binary_sensor, climate, number, select, sensor, switch, uart
-from esphome.const import CONF_ID, CONF_RX_PIN, CONF_INTERNAL
+from esphome.const import (
+    CONF_ID,
+    CONF_RX_PIN,
+    CONF_INTERNAL,
+    DEVICE_CLASS_DURATION,
+    DEVICE_CLASS_HUMIDITY,
+    DEVICE_CLASS_TEMPERATURE,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+    UNIT_CELSIUS,
+    UNIT_HOUR,
+    UNIT_PERCENT,
+)
 
 CODEOWNERS = ["JanM321"]
 DEPENDENCIES = ["uart"]
@@ -37,6 +49,10 @@ CONF_ERROR_CODE = "error_code"
 CONF_PIPE_TEMP_IN = "pipe_temp_in"
 CONF_PIPE_TEMP_MID = "pipe_temp_mid"
 CONF_PIPE_TEMP_OUT = "pipe_temp_out"
+CONF_HUMIDITY = "humidity"
+CONF_FAN_OPERATION_TIME = "fan_operation_time"
+CONF_INDOOR_UNIT_OPERATION_TIME = "indoor_unit_operation_time"
+CONF_PRECISE_ROOM_TEMPERATURE = "precise_room_temperature"
 
 CONF_DEFROST = "defrost"
 CONF_PREHEAT = "preheat"
@@ -71,10 +87,34 @@ CONFIG_SCHEMA = climate.climate_schema(LgController).extend(
         cv.Required(CONF_FAN_SPEED_HIGH): number.number_schema(LgNumber),
         cv.Required(CONF_SLEEP_TIMER): number.number_schema(LgNumber),
 
-        cv.Required(CONF_ERROR_CODE): sensor.sensor_schema(),
+        cv.Required(CONF_ERROR_CODE): sensor.sensor_schema(accuracy_decimals=0),
         cv.Required(CONF_PIPE_TEMP_IN): sensor.sensor_schema(),
         cv.Required(CONF_PIPE_TEMP_MID): sensor.sensor_schema(),
         cv.Required(CONF_PIPE_TEMP_OUT): sensor.sensor_schema(),
+        cv.Optional(CONF_HUMIDITY): sensor.sensor_schema(
+            unit_of_measurement=UNIT_PERCENT,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_HUMIDITY,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
+        cv.Optional(CONF_FAN_OPERATION_TIME): sensor.sensor_schema(
+            unit_of_measurement=UNIT_HOUR,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_DURATION,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+        ),
+        cv.Optional(CONF_INDOOR_UNIT_OPERATION_TIME): sensor.sensor_schema(
+            unit_of_measurement=UNIT_HOUR,
+            accuracy_decimals=0,
+            device_class=DEVICE_CLASS_DURATION,
+            state_class=STATE_CLASS_TOTAL_INCREASING,
+        ),
+        cv.Optional(CONF_PRECISE_ROOM_TEMPERATURE): sensor.sensor_schema(
+            unit_of_measurement=UNIT_CELSIUS,
+            accuracy_decimals=1,
+            device_class=DEVICE_CLASS_TEMPERATURE,
+            state_class=STATE_CLASS_MEASUREMENT,
+        ),
 
         cv.Required(CONF_DEFROST): binary_sensor.binary_sensor_schema(),
         cv.Required(CONF_PREHEAT): binary_sensor.binary_sensor_schema(),
@@ -120,6 +160,22 @@ async def to_code(config):
     pipe_temp_in = await sensor.new_sensor(config[CONF_PIPE_TEMP_IN])
     pipe_temp_mid = await sensor.new_sensor(config[CONF_PIPE_TEMP_MID])
     pipe_temp_out = await sensor.new_sensor(config[CONF_PIPE_TEMP_OUT])
+    if CONF_HUMIDITY in config:
+        humidity = await sensor.new_sensor(config[CONF_HUMIDITY])
+    else:
+        humidity = cg.nullptr
+    if CONF_FAN_OPERATION_TIME in config:
+        fan_operation_time = await sensor.new_sensor(config[CONF_FAN_OPERATION_TIME])
+    else:
+        fan_operation_time = cg.nullptr
+    if CONF_INDOOR_UNIT_OPERATION_TIME in config:
+        indoor_unit_operation_time = await sensor.new_sensor(config[CONF_INDOOR_UNIT_OPERATION_TIME])
+    else:
+        indoor_unit_operation_time = cg.nullptr
+    if CONF_PRECISE_ROOM_TEMPERATURE in config:
+        precise_room_temperature = await sensor.new_sensor(config[CONF_PRECISE_ROOM_TEMPERATURE])
+    else:
+        precise_room_temperature = cg.nullptr
 
     defrost = await binary_sensor.new_binary_sensor(config[CONF_DEFROST])
     preheat = await binary_sensor.new_binary_sensor(config[CONF_PREHEAT])
@@ -135,6 +191,8 @@ async def to_code(config):
                            fan_speed_slow, fan_speed_low, fan_speed_medium, fan_speed_high,
                            sleep_timer,
                            error_code, pipe_temp_in, pipe_temp_mid, pipe_temp_out,
+                           humidity, fan_operation_time, indoor_unit_operation_time,
+                           precise_room_temperature,
                            defrost, preheat, outdoor, auto_dry_active,
                            purifier, internal_thermistor, auto_dry,
                            config[CONF_FAHRENHEIT], config[CONF_IS_SLAVE_CONTROLLER])

--- a/esphome/components/lg_controller/lg-controller.h
+++ b/esphome/components/lg_controller/lg-controller.h
@@ -153,6 +153,10 @@ class LgController final : public climate::Climate, public uart::UARTDevice, pub
     esphome::sensor::Sensor& pipe_temp_in_;
     esphome::sensor::Sensor& pipe_temp_mid_;
     esphome::sensor::Sensor& pipe_temp_out_;
+    esphome::sensor::Sensor* humidity_;
+    esphome::sensor::Sensor* fan_operation_time_;
+    esphome::sensor::Sensor* indoor_unit_operation_time_;
+    esphome::sensor::Sensor* precise_room_temperature_;
     esphome::binary_sensor::BinarySensor& defrost_;
     esphome::binary_sensor::BinarySensor& preheat_;
     esphome::binary_sensor::BinarySensor& outdoor_;
@@ -283,7 +287,7 @@ class LgController final : public climate::Climate, public uart::UARTDevice, pub
         supported_traits_.set_supported_modes(device_modes);
         supported_traits_.set_supported_fan_modes(fan_modes);
         supported_traits_.set_supported_swing_modes(swing_modes);
-        supported_traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE);
+        supported_traits_.add_feature_flags(climate::CLIMATE_SUPPORTS_CURRENT_TEMPERATURE | climate::CLIMATE_SUPPORTS_ACTION);
         supported_traits_.set_visual_min_temperature(MIN_TEMP_SETPOINT);
         supported_traits_.set_visual_max_temperature(MAX_TEMP_SETPOINT);
         supported_traits_.set_visual_current_temperature_step(fahrenheit_ ? 1 : 0.5);
@@ -347,6 +351,10 @@ public:
                  sensor::Sensor* pipe_temp_in,
                  sensor::Sensor* pipe_temp_mid,
                  sensor::Sensor* pipe_temp_out,
+                 sensor::Sensor* humidity,
+                 sensor::Sensor* fan_operation_time,
+                 sensor::Sensor* indoor_unit_operation_time,
+                 sensor::Sensor* precise_room_temperature,
                  binary_sensor::BinarySensor* defrost,
                  binary_sensor::BinarySensor* preheat,
                  binary_sensor::BinarySensor* outdoor,
@@ -371,6 +379,10 @@ public:
         pipe_temp_in_(*pipe_temp_in),
         pipe_temp_mid_(*pipe_temp_mid),
         pipe_temp_out_(*pipe_temp_out),
+        humidity_(humidity),
+        fan_operation_time_(fan_operation_time),
+        indoor_unit_operation_time_(indoor_unit_operation_time),
+        precise_room_temperature_(precise_room_temperature),
         defrost_(*defrost),
         preheat_(*preheat),
         outdoor_(*outdoor),
@@ -467,6 +479,13 @@ public:
     void control(const climate::ClimateCall &call) override {
         if (call.get_mode().has_value()) {
             this->mode = *call.get_mode();
+            if (this->mode == climate::CLIMATE_MODE_OFF) {
+                this->action = climate::CLIMATE_ACTION_OFF;
+            } else if (this->mode == climate::CLIMATE_MODE_FAN_ONLY) {
+                this->action = climate::CLIMATE_ACTION_FAN;
+            } else if (this->action == climate::CLIMATE_ACTION_OFF) {
+                this->action = climate::CLIMATE_ACTION_IDLE;
+            }
         }
         if (call.get_target_temperature().has_value()) {
             this->target_temperature = *call.get_target_temperature();
@@ -486,6 +505,46 @@ public:
     }
 
 private:
+    bool set_action_from_status_(bool outdoor_on, bool preheating, bool defrosting, uint8_t temperature_flags) {
+        climate::ClimateAction action = climate::CLIMATE_ACTION_IDLE;
+        if (this->mode == climate::CLIMATE_MODE_OFF) {
+            action = climate::CLIMATE_ACTION_OFF;
+        } else if (defrosting) {
+            action = climate::CLIMATE_ACTION_DEFROSTING;
+        } else if (this->mode == climate::CLIMATE_MODE_FAN_ONLY) {
+            action = climate::CLIMATE_ACTION_FAN;
+        } else if (!outdoor_on || preheating) {
+            action = climate::CLIMATE_ACTION_IDLE;
+        } else {
+            switch (this->mode) {
+                case climate::CLIMATE_MODE_COOL:
+                    action = climate::CLIMATE_ACTION_COOLING;
+                    break;
+                case climate::CLIMATE_MODE_DRY:
+                    action = climate::CLIMATE_ACTION_DRYING;
+                    break;
+                case climate::CLIMATE_MODE_HEAT:
+                    action = climate::CLIMATE_ACTION_HEATING;
+                    break;
+                case climate::CLIMATE_MODE_HEAT_COOL:
+                    if (temperature_flags & 0x40) {
+                        action = climate::CLIMATE_ACTION_COOLING;
+                    } else if (temperature_flags & 0x80) {
+                        action = climate::CLIMATE_ACTION_HEATING;
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        if (this->action == action) {
+            return false;
+        }
+        this->action = action;
+        return true;
+    }
+
     // Sets position of vane index (1-4) to position (0-6).
     void set_vane_position(int index, int position) {
         if (index < 1 || index > 4) {
@@ -935,6 +994,9 @@ private:
             case 3: // 0xCB/AB/2B
                 process_type_b_settings_message(*sender, buffer);
                 break;
+            case 6: // 0xCE/AE/2E
+                process_type_e_status_message(*sender, buffer);
+                break;
             default:
                 return;
         }
@@ -958,7 +1020,8 @@ private:
         // change.
 
         defrost_.publish_state(buffer[3] & 0x4);
-        preheat_.publish_state(buffer[3] & 0x8);
+        bool preheating = buffer[3] & 0x8;
+        preheat_.publish_state(preheating);
 
         if (sender == MessageSender::Unit) {
             error_code_.publish_state(buffer[11]);
@@ -1009,10 +1072,16 @@ private:
         // changes we still have to send (or are sending) to the AC.
         if (pending_status_change_) {
             ESP_LOGD(TAG, "ignoring because pending change");
+            if (set_action_from_status_(outdoor_.state, preheating, defrost_.state, buffer[7])) {
+                publish_state();
+            }
             return;
         }
         if (pending_send_ == PendingSendKind::Status) {
             ESP_LOGD(TAG, "ignoring because pending send");
+            if (set_action_from_status_(outdoor_.state, preheating, defrost_.state, buffer[7])) {
+                publish_state();
+            }
             return;
         }
 
@@ -1104,6 +1173,7 @@ private:
             sleep_timer_.publish_state(minutes);
         }
 
+        set_action_from_status_(outdoor_.state, preheating, defrost_.state, buffer[7]);
         publish_state();
     }
 
@@ -1273,6 +1343,29 @@ private:
         }
     }
 
+    static uint16_t decode_uint16_(const uint8_t* buffer, size_t offset) {
+        return (uint16_t(buffer[offset]) << 8) | buffer[offset + 1];
+    }
+
+    void process_type_e_status_message(MessageSender sender, const uint8_t* buffer) {
+        if (sender == MessageSender::Slave || buffer[1] != 0x80) {
+            return;
+        }
+
+        if (humidity_ != nullptr) {
+            humidity_->publish_state(buffer[2]);
+        }
+        if (fan_operation_time_ != nullptr) {
+            fan_operation_time_->publish_state(decode_uint16_(buffer, 3));
+        }
+        if (indoor_unit_operation_time_ != nullptr) {
+            indoor_unit_operation_time_->publish_state(decode_uint16_(buffer, 6));
+        }
+        if (precise_room_temperature_ != nullptr) {
+            precise_room_temperature_->publish_state(float(buffer[10]) + float(buffer[11]) / 10.0f);
+        }
+    }
+
     void update() {
         ESP_LOGD(TAG, "update");
 
@@ -1338,6 +1431,7 @@ private:
                 sleep_timer_.publish_state(0);
                 ignore_sleep_timer_callback_ = false;
                 this->mode = climate::CLIMATE_MODE_OFF;
+                this->action = climate::CLIMATE_ACTION_OFF;
                 pending_status_change_ = true;
                 publish_state();
             } else if (optional<uint32_t> minutes = get_sleep_timer_minutes()) {


### PR DESCRIPTION
## Summary

This draft PR combines three small status/telemetry fixes for the ESPHome LG controller:

- Fixes #94 by publishing ESPHome/Home Assistant climate `action` from the live LG status frame.
- Fixes #132 by configuring the raw LG error-code sensor with integer-style display precision.
- Adds optional passive AE.80/CE.80 telemetry sensors for humidity, fan operation time, indoor unit operation time, and precise room temperature.

This supersedes #171. It ports the climate-action work onto a clean branch from `JanM321/main` and also addresses the #171 review comment about the preheat flag.

## Root Cause / Fix Log

### #94 Climate action

The component previously restored and published HVAC mode, but did not advertise or update `CLIMATE_SUPPORTS_ACTION`, so Home Assistant could only show the configured mode instead of the live action.

This PR now:

- Adds `CLIMATE_SUPPORTS_ACTION` to the climate traits.
- Updates `this->action` for `off`, `idle`, `cooling`, `drying`, `heating`, `fan`, and `defrosting`.
- Uses the live mode plus outdoor-unit state.
- Treats `preheat` as idle for the indoor unit, which matters on multi-split systems where the outdoor unit can run for another indoor unit.
- Uses the heat/cool status temperature flags (`0x40` cooling, `0x80` heating) when the mode is `heat_cool`.
- Keeps action in sync even while status changes/sends are pending, so HA does not lag behind the most recent bus status.

Mapping:

- `mode == off` -> `off`
- `defrost` bit set -> `defrosting`
- `mode == fan_only` -> `fan`
- outdoor unit off or preheat bit set -> `idle`
- `cool` + outdoor active -> `cooling`
- `dry` + outdoor active -> `drying`
- `heat` + outdoor active -> `heating`
- `heat_cool` + status flags -> `cooling` / `heating`, otherwise `idle`

### #132 Error code formatting

The LG error byte was already published raw, but the sensor schema did not specify integer-style precision. This PR keeps publishing the same raw LG byte and adds `accuracy_decimals: 0` without assigning a device class or state class that Home Assistant might misinterpret.

### AE.80 / CE.80 telemetry

The protocol notes document additional type-6 subtype-0x80 telemetry frames. This PR passively parses those frames and exposes optional sensors:

- `humidity`: byte 2, `%`, humidity device class, measurement, 0 decimals.
- `fan_operation_time`: bytes 3-4, `h`, duration device class, total_increasing, 0 decimals.
- `indoor_unit_operation_time`: bytes 6-7, `h`, duration device class, total_increasing, 0 decimals.
- `precise_room_temperature`: bytes 10-11 as integer + one decimal digit, `°C`, temperature device class, measurement, 1 decimal.

Frames are ignored for `Slave` sender messages and accepted only when subtype byte 1 is `0x80`. The precise room temperature is kept as a separate sensor and does not overwrite `current_temperature`.

## Validation

Repository validation:

- `git diff --check` passed.
- `uvx esphome config template.yaml` passed using a temporary `/tmp` copy with a valid base64 API key substituted for the upstream placeholder `my_key`.
- `uvx esphome compile template.yaml` passed using the same temporary copy.

Live Bioscoop LG Airco validation:

- `uvx esphome config bioscoop-lg-airco.yaml` passed.
- Live config retained WiFi SSID `Legacy`, static IP `192.168.2.166`, ESPHome API encryption, and passive/continuous BLE tracking with Bluetooth proxy inactive for Bermuda use.
- Live config compiled successfully from a temporary space-free `/tmp` build directory.
- OTA flash to `192.168.2.166` succeeded.
- ESPHome logs after OTA showed build `2026-06-01 07:29:03 +0200`, WiFi connected to `Legacy`, BLE tracker running, API reconnect successful.
- Home Assistant climate state confirmed `hvac_action` is now present. During live cooling test before the preheat refinement HA reported `hvac_action: cooling`; after the final preheat-aware flash the current unit state was `off` with `hvac_action: off`.
- New AE.80 sensors were registered in Home Assistant with the expected metadata, but remained `unknown` during the short live log window because this unit did not emit a CE.80/AE.80 frame in that sample.
- ESPHome log showed `Error Code >> 0` with the generated code setting `error_code->set_accuracy_decimals(0)`. HA's backend state API still stores the value as a numeric string (`0.0`), which appears to be HA/ESPHome sensor state representation rather than a firmware precision issue.

## Known Limitation

The AE.80/CE.80 sensors are passive. They only publish values when the LG bus actually emits a matching type-6 subtype-0x80 frame.
